### PR TITLE
[CLOUD-314]: Additional fetches and data enrichments to tables

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -435,7 +435,7 @@ web:
   # Container image configuration
   image:
     repository: prorobotech/openapi-ui
-    tag: release-1.1.0-c5573016
+    tag: release-1.2.0-e3aa30ae
     pullPolicy: IfNotPresent
 
   # Networking configuration for the container


### PR DESCRIPTION
Included in:

- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/77
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/75

Changes:
- `CCO` with `type: factory` now support `urlsToFetch` in `customProps`. Row item will be req0, first urlToFetch will be req1
- Factory: EnrichedTable: \+ `additionalReqsDataToEachItem?: number[]`. Numbers are req indexes from factorie's `urlsToFetch`. Will be mapped to each row like `{...row, additionalReqsData: [req0, req1, ...]}`
- API/Builtin Tables support now search param like `?resources=apps/v1/deployments,/v1/pods`. Result will be like above