### PR TITLE
[CLOUD-119]: PodTerminal - show error when container socket fails

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -348,7 +348,7 @@ bff:
   # Container image configuration
   image:
     repository: prorobotech/openapi-ui-k8s-bff
-    tag: v1.2.0-9dea64b4
+    tag: release-1.2.1-1c9a35a5
     pullPolicy: IfNotPresent
 
   # Networking configuration for the container
@@ -359,7 +359,6 @@ bff:
   env:
     BASE_API_GROUP: "front.in-cloud.io"
     BASE_API_VERSION: "v1alpha1"
-    DEBUG_CONTAINER_IMAGE: "nicolaka/netshoot:v0.13"
     LOGGER: "TRUE"
     LOGGER_WITH_HEADERS: "TRUE"
     PORT: "8082"
@@ -449,7 +448,7 @@ web:
   # Container image configuration
   image:
     repository: prorobotech/openapi-ui
-    tag: v1.2.0-f77b3241
+    tag: release-1.2.1-9c64107a
     pullPolicy: IfNotPresent
 
   # Networking configuration for the container

--- a/values.yaml
+++ b/values.yaml
@@ -348,7 +348,7 @@ bff:
   # Container image configuration
   image:
     repository: prorobotech/openapi-ui-k8s-bff
-    tag: release-1.2.1-1c9a35a5
+    tag: release-1.2.1-a439816b
     pullPolicy: IfNotPresent
 
   # Networking configuration for the container
@@ -448,7 +448,7 @@ web:
   # Container image configuration
   image:
     repository: prorobotech/openapi-ui
-    tag: release-1.2.1-9c64107a
+    tag: release-1.2.1-78122065
     pullPolicy: IfNotPresent
 
   # Networking configuration for the container


### PR DESCRIPTION
Includes:
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/98

Included into:
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/100
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/101
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/102
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/104
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/105
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/106
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/107
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/108
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/109
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/110
- https://github.com/PRO-Robotech/in-cloud-web-chart/pull/111